### PR TITLE
Fix relative path bug

### DIFF
--- a/src/File/File.php
+++ b/src/File/File.php
@@ -81,7 +81,11 @@ class File implements FileInterface
      */
     public function getRelativePath()
     {
-        return str_replace($this->projectPath . DIRECTORY_SEPARATOR, '', $this->filePath);
+        $projectPath = $this->projectPath . DIRECTORY_SEPARATOR;
+
+        $relativePath = substr_replace($this->filePath, '', 0, strlen($projectPath));
+
+        return ltrim($relativePath, DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/src/File/File.php
+++ b/src/File/File.php
@@ -61,7 +61,7 @@ class File implements FileInterface
     ) {
         $this->fileStatus  = $fileStatus;
         $this->filePath    = $filePath;
-        $this->projectPath = $projectPath;
+        $this->projectPath = rtrim($projectPath, DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/tests/unit/File/FileTest.php
+++ b/tests/unit/File/FileTest.php
@@ -24,6 +24,7 @@ class FileTest extends TestCase
 
     protected $projectPath;
 
+    /** @var File $file */
     protected $file;
 
     public function setUp()

--- a/tests/unit/File/FileTest.php
+++ b/tests/unit/File/FileTest.php
@@ -46,9 +46,18 @@ class FileTest extends TestCase
 
     public function testGetRelativePath()
     {
-        $expected = str_replace($this->projectPath . DIRECTORY_SEPARATOR, '', $this->filePath);
+        $filePath = "/app/example/app/TestFile.php";
+        $basePath = "/app";
+        $file = new File("M", $filePath, $basePath);
 
-        $this->assertSame($expected, $this->file->getRelativePath());
+        $this->assertEquals("example/app/TestFile.php", $file->getRelativePath());
+
+        //it can also handle when a trailing slash is present on the base path
+        $filePath = "/app/example2/app/TestFile2.php";
+        $basePath = "/app/";
+        $file = new File("A", $filePath, $basePath);
+
+        $this->assertEquals("example2/app/TestFile2.php", $file->getRelativePath());
     }
 
     public function testGetFullPathWithNoCachedPath()


### PR DESCRIPTION
Before this PR, there was a string replace of the base path when calling `getRelativePath()`. This was not ideal as if the file path contained the same as the base path, this would be completely replaced.

Take the following example with the previous code:

```
$base = "/example"
$fileName = "/example/file/example/test.php"
```

By calling `getRelativePath`, this would incorrectly return `file/test.php`.
